### PR TITLE
chore: create database file with first data insertion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ nosetests.xml
 *.db.yml
 
 .DS_Store
+
+# Virtual environment
+venv


### PR DESCRIPTION
## Background

When creating a new database with `JSONSttorage`, a new JSON file will be created even before inserting any data, this PR suggests creating the JSON file only with the first data insertion.

Example
```python

from tinydb import TinyDB

db = TinyDB('db.json')

```

the `db.json` is not created yet.
after the first insertion
```python
db.insert({'int': 1, 'char': 'a'})
```
`db.json` will be created.

_If the file already exists before initializing the DB, it will be used._

## Changes
- Only create the JSON file with he first insertion.
- Updated unit test.


## Test
<details><summary>Unit Test</summary>

```bash

Name                    Stmts   Miss Branch BrPart  Cover
---------------------------------------------------------
tinydb\__init__.py          5      0      0      0   100%
tinydb\database.py         53      0     12      0   100%
tinydb\middlewares.py      33      0      6      0   100%
tinydb\mypy_plugin.py      25     25      2      0     0%
tinydb\operations.py       24      0      0      0   100%
tinydb\queries.py         128      3     72      5    96%
tinydb\storages.py         67      0     21      1    99%
tinydb\table.py           214      1    102      1    99%
tinydb\utils.py            72      1     24      1    98%
tinydb\version.py           1      0      0      0   100%
---------------------------------------------------------
TOTAL                     622     30    239      8    95%


======================================================================= 202 passed in 3.24s =======================================================================
```

<details>

<details><summary>Local Test</summary>



<details>
